### PR TITLE
Fixing webhook trigger - logger levels and standardizing the messages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,13 @@
 {
   "permissions": {
     "allow": [
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:javadoc.jenkins.io)",
+      "WebFetch(domain:docs.cloudbees.com)",
+      "Bash(curl:*)",
+      "Bash(mvn checkstyle:check:*)"
     ]
   }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -609,8 +609,10 @@ public class GerritServer implements Describable<GerritServer>, Action {
 
                 if (useWebhookForEvents) {
                     // Webhook mode: SSH connection for sending results, webhook for receiving events
-                    logger.info("Server " + name + " configured for webhook event reception "
-                            + "(SSH connection established for sending results)");
+                    logger.info("Server {} configured for webhook event reception "
+                            + "(SSH connection established for sending results)", name);
+                    logger.info("Webhook endpoint: {}/gerrit-webhook/", Jenkins.get().getRootUrl());
+                    logger.info("Events will be received via HTTP POST, SSH connection for results only");
                     // Do NOT set event handler - events come via webhook instead
                 } else {
                     // SSH mode: SSH connection for both receiving events and sending results

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -580,6 +580,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
      *
      */
     public synchronized void startConnection() {
+        logger.info("Starting {} server connection", getName());
         checkPermission();
         if (!config.hasDefaultValues()) {
             if (gerritConnection == null) {
@@ -638,6 +639,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
      *
      */
     public synchronized void stopConnection() {
+        logger.info("Stopping {} server connection", getName());
         checkPermission();
         if (gerritConnection != null) {
             gerritConnection.shutdown(true);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -44,8 +44,6 @@ import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Calendar;
@@ -70,8 +68,6 @@ import static com.sonymobile.tools.gerrit.gerritevents.GerritDefaultValues.DEFAU
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 public class Config implements IGerritHudsonTriggerConfig {
-
-    private static final Logger logger = LoggerFactory.getLogger(Config.class);
 
     /**
      * Default verified vote to Gerrit when a build is started.
@@ -239,7 +235,6 @@ public class Config implements IGerritHudsonTriggerConfig {
     private boolean voteSameTopic;
     private ConnectionType connectionType;
     private WebhookConfig webhookConfig;
-    private boolean logWebhookRequests;
 
     /**
      * Constructor.
@@ -313,20 +308,14 @@ public class Config implements IGerritHudsonTriggerConfig {
 
         // Copy webhook configuration if source is a Config instance
         connectionType = config.getConnectionType();
-        if (connectionType == ConnectionType.WEBHOOK) {
-            logger.info("Copying webhook configuration: " + config.getWebhookConfig());
-            if (config instanceof Config) {
-                logWebhookRequests = ((Config)config).isLogWebhookRequests();
-            }
-            if (config.getWebhookConfig() != null) {
-                webhookConfig = new WebhookConfig();
-                webhookConfig.setEnabled(config.getWebhookConfig().isEnabled());
-                webhookConfig.setWebhookSecret(config.getWebhookConfig().getWebhookSecret());
-                webhookConfig.setHmacSecret(config.getWebhookConfig().getHmacSecret());
-                webhookConfig.setRequireSecretToken(config.getWebhookConfig().isRequireSecretToken());
-                webhookConfig.setRequireHmacSignature(config.getWebhookConfig().isRequireHmacSignature());
-                webhookConfig.setAllowedIpAddresses(config.getWebhookConfig().getAllowedIpAddresses());
-            }
+        if (connectionType == ConnectionType.WEBHOOK && config.getWebhookConfig() != null) {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setEnabled(config.getWebhookConfig().isEnabled());
+            webhookConfig.setWebhookSecret(config.getWebhookConfig().getWebhookSecret());
+            webhookConfig.setHmacSecret(config.getWebhookConfig().getHmacSecret());
+            webhookConfig.setRequireSecretToken(config.getWebhookConfig().isRequireSecretToken());
+            webhookConfig.setRequireHmacSignature(config.getWebhookConfig().isRequireHmacSignature());
+            webhookConfig.setAllowedIpAddresses(config.getWebhookConfig().getAllowedIpAddresses());
         }
     }
 
@@ -358,8 +347,6 @@ public class Config implements IGerritHudsonTriggerConfig {
 
         voteSameTopic = formData.optBoolean("voteSameTopic", false);
 
-        // Parse connection type and webhook configuration
-        logger.info("Parsing WEBHOOK");
         parseConnectionTypeAndWebhook(formData);
 
         numberOfWorkerThreads = formData.optInt(
@@ -479,14 +466,12 @@ public class Config implements IGerritHudsonTriggerConfig {
         // and all fields from within that radio block
         if (!formData.has("connectionType")) {
             connectionType = DEFAULT_CONNECTION_TYPE;
-            logWebhookRequests = false;
             webhookConfig = null;
             return;
         }
 
         JSONObject connectionTypeData = formData.getJSONObject("connectionType");
         String connTypeStr = connectionTypeData.optString("value", null);
-        logger.info("Parsing connection type: " + connTypeStr);
 
         if (connTypeStr != null && !connTypeStr.isEmpty()) {
             try {
@@ -500,14 +485,9 @@ public class Config implements IGerritHudsonTriggerConfig {
 
         // If webhook mode is selected, parse webhook settings
         if (connectionType == ConnectionType.WEBHOOK) {
-            // Parse logWebhookRequests from the connectionType object
-            logWebhookRequests = connectionTypeData.optBoolean("logWebhookRequests", false);
-            logger.info("logWebhookRequests: " + logWebhookRequests);
-
             // Parse webhook authentication config if the optional block is checked
             if (connectionTypeData.has("webhookConfig")) {
                 JSONObject webhookData = connectionTypeData.getJSONObject("webhookConfig");
-                logger.info("Parsing webhook authentication config: " + webhookData);
                 webhookConfig = new WebhookConfig();
                 webhookConfig.setEnabled(true);
                 if (webhookData.has("webhookSecret")) {
@@ -524,12 +504,10 @@ public class Config implements IGerritHudsonTriggerConfig {
                 }
             } else {
                 // Webhook mode selected but authentication not enabled
-                logger.info("Webhook mode without authentication");
                 webhookConfig = null;
             }
         } else {
             // SSH mode - clear webhook config
-            logWebhookRequests = false;
             webhookConfig = null;
         }
     }
@@ -1042,24 +1020,6 @@ public class Config implements IGerritHudsonTriggerConfig {
      */
     public void setWebhookConfig(WebhookConfig webhookConfig) {
         this.webhookConfig = webhookConfig;
-    }
-
-    /**
-     * Gets whether webhook requests should be logged for debugging.
-     *
-     * @return true if webhook logging is enabled, false otherwise
-     */
-    public boolean isLogWebhookRequests() {
-        return logWebhookRequests;
-    }
-
-    /**
-     * Sets whether webhook requests should be logged for debugging.
-     *
-     * @param logWebhookRequests true to enable webhook logging, false otherwise
-     */
-    public void setLogWebhookRequests(boolean logWebhookRequests) {
-        this.logWebhookRequests = logWebhookRequests;
     }
 
     @Override

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticator.java
@@ -68,9 +68,10 @@ public class WebhookAuthenticator {
      *
      * @param request the HTTP request to authenticate
      * @param server the Gerrit server configuration
+     * @param payload the webhook payload for HMAC signature validation
      * @return true if authentication succeeds, false otherwise
      */
-    public boolean authenticate(HttpServletRequest request, GerritServer server) {
+    public boolean authenticate(HttpServletRequest request, GerritServer server, String payload) {
         if (request == null || server == null) {
             LOGGER.warning("Cannot authenticate null request or server");
             return false;
@@ -93,7 +94,7 @@ public class WebhookAuthenticator {
             }
 
             // 3. Check HMAC signature (if configured)
-            if (!isSignatureValid(request, server)) {
+            if (!isSignatureValid(request, server, payload)) {
                 LOGGER.fine("Invalid HMAC signature");
                 return false;
             }
@@ -174,9 +175,10 @@ public class WebhookAuthenticator {
      *
      * @param request the HTTP request
      * @param server the Gerrit server configuration
+     * @param payload the webhook payload to validate against the signature
      * @return true if signature is valid or no signature validation is configured
      */
-    private boolean isSignatureValid(HttpServletRequest request, GerritServer server) {
+    private boolean isSignatureValid(HttpServletRequest request, GerritServer server, String payload) {
         String hmacSecret = getWebhookHmacSecret(server);
 
         if (hmacSecret == null || hmacSecret.trim().isEmpty()) {
@@ -192,10 +194,8 @@ public class WebhookAuthenticator {
         }
 
         try {
-            // Get the request body (payload) for signature calculation
-            String payload = getRequestPayload(request);
             if (payload == null) {
-                LOGGER.warning("Unable to read request payload for signature validation");
+                LOGGER.warning("Unable to get request payload for signature validation");
                 return false;
             }
 
@@ -340,17 +340,4 @@ public class WebhookAuthenticator {
         return null;
     }
 
-    /**
-     * Reads the request payload/body.
-     * TODO: This needs to be implemented to read from the request input stream.
-     *
-     * @param request the HTTP request
-     * @return the request payload as string, or null if reading fails
-     */
-    private String getRequestPayload(HttpServletRequest request) {
-        // TODO: Implement payload reading
-        // This should read the request body that was already consumed
-        // We may need to cache it during the initial read in WebhookEventReceiver
-        return null;
-    }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticator.java
@@ -82,19 +82,19 @@ public class WebhookAuthenticator {
 
             // 1. Check IP address whitelist (if configured)
             if (!isIpAllowed(request, server)) {
-                LOGGER.warning("Request from IP address " + request.getRemoteAddr() + " not allowed");
+                LOGGER.fine("Request from IP address " + request.getRemoteAddr() + " not allowed");
                 return false;
             }
 
             // 2. Check secret token (if configured)
             if (!isTokenValid(request, server)) {
-                LOGGER.warning("Invalid or missing webhook token");
+                LOGGER.fine("Invalid or missing webhook token");
                 return false;
             }
 
             // 3. Check HMAC signature (if configured)
             if (!isSignatureValid(request, server)) {
-                LOGGER.warning("Invalid HMAC signature");
+                LOGGER.fine("Invalid HMAC signature");
                 return false;
             }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticator.java
@@ -102,7 +102,7 @@ public class WebhookAuthenticator {
             return true;
 
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Error during webhook authentication", e);
+            LOGGER.log(Level.WARNING, "Error during webhook authentication", e);
             return false;
         }
     }
@@ -138,7 +138,6 @@ public class WebhookAuthenticator {
      * @return true if token is valid or no token is configured
      */
     private boolean isTokenValid(HttpServletRequest request, GerritServer server) {
-        // TODO: Get configured secret token from server config
         String configuredToken = getWebhookSecret(server);
 
         if (configuredToken == null || configuredToken.trim().isEmpty()) {
@@ -178,7 +177,6 @@ public class WebhookAuthenticator {
      * @return true if signature is valid or no signature validation is configured
      */
     private boolean isSignatureValid(HttpServletRequest request, GerritServer server) {
-        // TODO: Get configured HMAC secret from server config
         String hmacSecret = getWebhookHmacSecret(server);
 
         if (hmacSecret == null || hmacSecret.trim().isEmpty()) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookCrumbExclusion.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookCrumbExclusion.java
@@ -65,19 +65,20 @@ public class WebhookCrumbExclusion extends CrumbExclusion {
         String contextPath = req.getContextPath();
         String servletPath = req.getServletPath();
 
-        LOGGER.log(Level.INFO, "WebhookCrumbExclusion.process() - URI: {0}, pathInfo: {1}, "
-                  + "contextPath: {2}, servletPath: {3}, EXCLUSION_PATH: {4}",
-                  new Object[]{requestURI, pathInfo, contextPath, servletPath, EXCLUSION_PATH});
-
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "WebhookCrumbExclusion.process() - URI: {0}, pathInfo: {1}, "
+                            + "contextPath: {2}, servletPath: {3}, EXCLUSION_PATH: {4}",
+                    new Object[]{requestURI, pathInfo, contextPath, servletPath, EXCLUSION_PATH});
+        }
         // Check if this request is for our webhook endpoint
         // Use contains() to be more forgiving than equals()
         boolean isWebhookPath = (pathInfo != null && pathInfo.contains(EXCLUSION_PATH))
                              || (requestURI != null && requestURI.contains(EXCLUSION_PATH));
 
         if (isWebhookPath) {
-            LOGGER.log(Level.INFO, "Webhook path matched! Calling chain.doFilter() to continue processing");
+            LOGGER.log(Level.FINE, "Webhook path matched! Calling chain.doFilter() to continue processing");
             chain.doFilter(req, resp);
-            LOGGER.log(Level.INFO, "chain.doFilter() completed, returning true");
+            LOGGER.log(Level.FINE, "chain.doFilter() completed, returning true");
             return true;
         }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventProcessor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventProcessor.java
@@ -80,7 +80,7 @@ public class WebhookEventProcessor {
             // Set the provider information on the event
             setProviderInfo(event, server);
 
-            LOGGER.log(Level.INFO, "Successfully processed webhook event: {0}",
+            LOGGER.log(Level.FINE, "Successfully processed webhook event: {0}",
                       event.getClass().getSimpleName());
 
             return event;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
@@ -96,15 +96,12 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
      * @throws IOException if I/O error occurs
      */
     public void doIndex(StaplerRequest req) throws IOException {
-        LOGGER.log(Level.INFO, "=== doIndex() CALLED === method: {0}, from: {1}",
-            new Object[]{req.getMethod(), req.getRemoteAddr()});
-
         // Get response from Stapler context
         StaplerResponse rsp = org.kohsuke.stapler.Stapler.getCurrentResponse();
 
         // Only handle POST requests
         if (!"POST".equals(req.getMethod())) {
-            LOGGER.log(Level.WARNING, "Rejecting non-POST request: {0}", req.getMethod());
+            LOGGER.log(Level.FINE, "Rejecting non-POST request: {0}", req.getMethod());
             if (rsp != null) {
                 rsp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
                     "Only POST method is supported for webhook events");
@@ -124,7 +121,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
      */
     private void handleWebhookEvent(HttpServletRequest req, HttpServletResponse rsp)
             throws IOException {
-        LOGGER.log(Level.INFO, "handleWebhookEvent() - processing request from {0}", req.getRemoteAddr());
+        LOGGER.log(Level.FINE, "handleWebhookEvent() - processing request from {0}", req.getRemoteAddr());
         try {
             // Read the payload first
             String payload = IOUtils.toString(req.getReader());
@@ -142,20 +139,10 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
                 return;
             }
 
-            // Check if webhook request logging is enabled
-            boolean logRequests = false;
-            if (server.getConfig() instanceof com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config) {
-                com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config config =
-                        (com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config)server.getConfig();
-                logRequests = config.isLogWebhookRequests();
-            }
-
-            if (logRequests) {
-                LOGGER.log(Level.INFO, "Webhook request received for server {0}", server.getName());
-                LOGGER.log(Level.INFO, "Webhook payload: {0}", payload);
-                LOGGER.log(Level.INFO, "Request headers: {0}", formatHeaders(req));
-            } else {
-                LOGGER.log(Level.FINE, "Received webhook payload: {0}", payload);
+            if (LOGGER.isLoggable(Level.FINE)){
+                LOGGER.log(Level.FINE, "Webhook request received for server {0}", server.getName());
+                LOGGER.log(Level.FINE, "Webhook payload: {0}", payload);
+                LOGGER.log(Level.FINE, "Request headers: {0}", formatHeaders(req));
             }
 
             // Check if webhooks are enabled for this server
@@ -167,9 +154,6 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
 
             // Authenticate the request
             if (!authenticator.authenticate(req, server)) {
-                if (logRequests) {
-                    LOGGER.log(Level.WARNING, "Webhook authentication failed for server {0}", server.getName());
-                }
                 sendError(rsp, HttpServletResponse.SC_UNAUTHORIZED,
                          "Webhook authentication failed");
                 return;
@@ -178,9 +162,6 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
             // Process the webhook payload
             GerritEvent event = eventProcessor.processWebhookPayload(payload, server);
             if (event == null) {
-                if (logRequests) {
-                    LOGGER.log(Level.WARNING, "Unable to process webhook payload for server {0}", server.getName());
-                }
                 sendError(rsp, HttpServletResponse.SC_BAD_REQUEST,
                          "Unable to process webhook payload");
                 return;
@@ -194,10 +175,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
             rsp.setContentType("application/json");
             rsp.getWriter().write("{\"status\":\"success\",\"message\":\"Event processed successfully\"}");
 
-            if (logRequests) {
-                LOGGER.log(Level.INFO, "Successfully processed webhook event {0} for server {1}",
-                          new Object[]{event.getClass().getSimpleName(), server.getName()});
-            } else {
+            if (LOGGER.isLoggable(Level.FINE)){
                 LOGGER.log(Level.FINE, "Successfully processed webhook event {0} for server {1}",
                           new Object[]{event.getClass().getSimpleName(), server.getName()});
             }
@@ -275,7 +253,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
         }
 
         // Fall back to first webhook-enabled server
-        LOGGER.log(Level.INFO,
+        LOGGER.log(Level.WARNING,
                   "Multiple webhook servers configured but could not identify from payload. "
                   + "Using first webhook-enabled server: {0}",
                   webhookServers.get(0).getName());
@@ -302,7 +280,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
 
             return null;
         } catch (Exception e) {
-            LOGGER.log(Level.FINE, "Could not extract change URL from payload", e);
+            LOGGER.log(Level.SEVERE, "Could not extract change URL from payload", e);
             return null;
         }
     }
@@ -341,10 +319,12 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
         // Check if server is configured for webhook mode (not SSH)
         if (config.getConnectionType()
                 != com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config.ConnectionType.WEBHOOK) {
-            LOGGER.log(Level.WARNING,
-                      "Server {0} is not configured for webhook mode (current mode: {1}). "
-                      + "Webhooks can only be received when connection type is set to WEBHOOK.",
-                      new Object[]{server.getName(), config.getConnectionType()});
+            if (LOGGER.isLoggable(Level.FINE)){
+                LOGGER.log(Level.FINE,
+                        "Server {0} is not configured for webhook mode (current mode: {1}). "
+                                + "Webhooks can only be received when connection type is set to WEBHOOK.",
+                        new Object[]{server.getName(), config.getConnectionType()});
+            }
             return false;
         }
 
@@ -354,8 +334,10 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
         if (config.getWebhookConfig() != null) {
             authStatus = "enabled";
         }
-        LOGGER.log(Level.INFO, "Webhook validation passed for server {0} (authentication: {1})",
-                  new Object[]{server.getName(), authStatus});
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "Webhook validation passed for server {0} (authentication: {1})",
+                    new Object[]{server.getName(), authStatus});
+        }
         return true;
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
@@ -139,7 +139,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
                 return;
             }
 
-            if (LOGGER.isLoggable(Level.FINE)){
+            if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Webhook request received for server {0}", server.getName());
                 LOGGER.log(Level.FINE, "Webhook payload: {0}", payload);
                 LOGGER.log(Level.FINE, "Request headers: {0}", formatHeaders(req));
@@ -175,7 +175,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
             rsp.setContentType("application/json");
             rsp.getWriter().write("{\"status\":\"success\",\"message\":\"Event processed successfully\"}");
 
-            if (LOGGER.isLoggable(Level.FINE)){
+            if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Successfully processed webhook event {0} for server {1}",
                           new Object[]{event.getClass().getSimpleName(), server.getName()});
             }
@@ -319,7 +319,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
         // Check if server is configured for webhook mode (not SSH)
         if (config.getConnectionType()
                 != com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config.ConnectionType.WEBHOOK) {
-            if (LOGGER.isLoggable(Level.FINE)){
+            if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE,
                         "Server {0} is not configured for webhook mode (current mode: {1}). "
                                 + "Webhooks can only be received when connection type is set to WEBHOOK.",

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
@@ -204,60 +204,51 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
             LOGGER.log(Level.WARNING, "No Gerrit servers configured");
             return null;
         }
-
-        // Get list of webhook-enabled servers
-        java.util.List<GerritServer> webhookServers = new java.util.ArrayList<>();
-        for (GerritServer server : plugin.getServers()) {
-            if (server.getConfig() instanceof com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config) {
-                com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config config =
-                        (com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config)server.getConfig();
-
-                if (config.getConnectionType()
-                        == com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config.ConnectionType.WEBHOOK) {
-                    webhookServers.add(server);
-                }
-            }
-        }
-
-        if (webhookServers.isEmpty()) {
-            LOGGER.log(Level.WARNING,
-                      "No server configured for webhook mode. Please configure at least one server "
-                      + "with connection type set to WEBHOOK to receive webhook events.");
+        String changeUrl = null;
+        try {
+            // Extract change URL from payload if available
+            changeUrl = extractChangeUrl(payload);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to parse payload for server identification", e);
             return null;
         }
 
-        // If only one webhook server, return it
-        if (webhookServers.size() == 1) {
-            LOGGER.log(Level.FINE, "Using only webhook-enabled server: {0}", webhookServers.get(0).getName());
-            return webhookServers.get(0);
-        }
-
-        // Multiple webhook servers - try to identify from payload
-        try {
-            // Extract change URL from payload if available
-            String changeUrl = extractChangeUrl(payload);
-            if (changeUrl != null && !changeUrl.isEmpty()) {
-                // Match against frontend URLs
-                for (GerritServer server : webhookServers) {
-                    String frontendUrl = server.getFrontEndUrl();
-                    if (frontendUrl != null && changeUrl.startsWith(frontendUrl)) {
-                        LOGGER.log(Level.FINE,
-                                  "Matched webhook to server {0} by Frontend URL: {1}",
-                                  new Object[]{server.getName(), frontendUrl});
-                        return server;
+        boolean serverWithWebhookConfiguredFound = false;
+        if (changeUrl != null && !changeUrl.isEmpty()) {
+            for (GerritServer server : plugin.getServers()) {
+                if (server.getConfig() instanceof com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config) {
+                    com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config config =
+                            (com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config)server.getConfig();
+                    if (config.getConnectionType()
+                            == com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config.ConnectionType.WEBHOOK) {
+                        serverWithWebhookConfiguredFound = true;
+                        String frontendUrl = server.getFrontEndUrl();
+                        if (frontendUrl != null && changeUrl.startsWith(frontendUrl)) {
+                            if (LOGGER.isLoggable(Level.FINE)) {
+                                LOGGER.log(Level.FINE,
+                                        "Matched webhook to server {0} by Frontend URL: {1}",
+                                        new Object[]{server.getName(), frontendUrl});
+                            }
+                            return server;
+                        }
                     }
                 }
             }
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to parse payload for server identification", e);
-        }
+            if (!serverWithWebhookConfiguredFound) {
+                LOGGER.log(Level.WARNING,
+                        "No server configured for webhook mode. Please configure at least one server "
+                                + "with connection type set to WEBHOOK to receive webhook events.");
+            } else {
+                LOGGER.log(Level.WARNING,
+                        "No server matched payload's changeUrl");
+            }
+            return null;
 
-        // Fall back to first webhook-enabled server
-        LOGGER.log(Level.WARNING,
-                  "Multiple webhook servers configured but could not identify from payload. "
-                  + "Using first webhook-enabled server: {0}",
-                  webhookServers.get(0).getName());
-        return webhookServers.get(0);
+        } else {
+            LOGGER.log(Level.WARNING,
+                    "ChangeURL is null or empty, and it is mandatory. The server cannot be identified.");
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookEventReceiver.java
@@ -153,7 +153,7 @@ public class WebhookEventReceiver extends WebhookCrumbExclusion implements Unpro
             }
 
             // Authenticate the request
-            if (!authenticator.authenticate(req, server)) {
+            if (!authenticator.authenticate(req, server, payload)) {
                 sendError(rsp, HttpServletResponse.SC_UNAUTHORIZED,
                          "Webhook authentication failed");
                 return;

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -130,7 +130,7 @@
                             </div>
                             <div class="jenkins-form-item">
                                 <div class="jenkins-form-description">
-                                    <strong>Webhook URL:</strong> <code>${rootURL}/gerrit-webhook</code>
+                                    <strong>Webhook URL:</strong> <code>${rootURL}/gerrit-webhook/</code>
                                 </div>
                             </div>
                         </f:block>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -134,12 +134,6 @@
                                 </div>
                             </div>
                         </f:block>
-                        <f:entry title="${%Log Webhook Requests for debugging)}"
-                                 help="/plugin/gerrit-trigger/help-WebhookLogRequests.html">
-                            <f:checkbox name="logWebhookRequests"
-                                        checked="${it.config.logWebhookRequests}"
-                                        default="false"/>
-                        </f:entry>
                         <f:optionalBlock name="webhookConfig"
                                          title="${%Enable Webhook Authentication}"
                                          checked="${it.config.webhookConfig != null and it.config.webhookConfig.enabled}"

--- a/src/main/webapp/help-ConnectionTypeSSH.html
+++ b/src/main/webapp/help-ConnectionTypeSSH.html
@@ -1,0 +1,33 @@
+<p>The traditional connection method where Gerrit events are received via SSH stream-events connection.</p>
+
+<p><strong>How it works:</strong></p>
+<ul>
+    <li>Jenkins establishes a persistent SSH connection to the Gerrit server</li>
+    <li>Gerrit streams events in real-time using the <code>gerrit stream-events</code> command</li>
+    <li>The same SSH connection is used to send build results back to Gerrit (review comments, votes)</li>
+</ul>
+
+<p><strong>Requirements:</strong></p>
+<ul>
+    <li>SSH access to the Gerrit server must be enabled</li>
+    <li>Jenkins must have SSH key authentication configured for the Gerrit user</li>
+    <li>The Gerrit user must have appropriate permissions to stream events</li>
+    <li>Network connectivity on the SSH port (typically 29418) must be available</li>
+</ul>
+
+<p><strong>Benefits:</strong></p>
+<ul>
+    <li><strong>Real-time:</strong> Events are delivered immediately with minimal latency</li>
+    <li><strong>Reliable:</strong> Persistent connection with automatic reconnection on failure</li>
+    <li><strong>Bidirectional:</strong> Same connection used for receiving events and sending build results</li>
+    <li><strong>Proven:</strong> The original and most widely tested connection method</li>
+</ul>
+
+<p><strong>Considerations:</strong></p>
+<ul>
+    <li>Requires maintaining a persistent SSH connection (may be blocked by some firewalls/proxies)</li>
+    <li>May require special firewall rules for SSH access</li>
+    <li>Connection drops will temporarily interrupt event delivery until reconnection</li>
+</ul>
+
+<p><strong>Recommended for:</strong> Most deployments, especially when Jenkins and Gerrit are in the same network or when SSH access is readily available.</p>

--- a/src/main/webapp/help-ConnectionTypeWebhook.html
+++ b/src/main/webapp/help-ConnectionTypeWebhook.html
@@ -1,0 +1,46 @@
+<p>Events are received via HTTP POST webhooks from the Gerrit server, while maintaining SSH connection for sending build results.</p>
+
+<p><strong>How it works:</strong></p>
+<ul>
+    <li>Gerrit sends events as HTTP POST requests to Jenkins webhook endpoint</li>
+    <li>Jenkins receives and processes events through the webhook endpoint</li>
+    <li>SSH connection is still maintained for sending build results back to Gerrit (review comments, votes)</li>
+    <li>Webhook authentication can be configured (secret token, HMAC signature, IP whitelisting)</li>
+</ul>
+
+<p><strong>Webhook Endpoint:</strong></p>
+<code>$JENKINS_URL/gerrit-webhook/</code>
+<p><strong>Important:</strong> The trailing slash (<code>/</code>) is mandatory. Ensure your Gerrit webhook configuration includes it.</p>
+
+<p><strong>Requirements:</strong></p>
+<ul>
+    <li>Gerrit server must be configured with webhook plugin or built-in webhook support</li>
+    <li>HTTP/HTTPS connectivity from Gerrit to Jenkins must be available</li>
+    <li>SSH access is still required for sending build results back to Gerrit</li>
+    <li>Webhook authentication should be configured for production environments</li>
+</ul>
+
+<p><strong>Benefits:</strong></p>
+<ul>
+    <li><strong>Firewall-friendly:</strong> Uses standard HTTP/HTTPS protocols instead of persistent SSH connections</li>
+    <li><strong>Flexible authentication:</strong> Supports multiple authentication methods (tokens, HMAC, IP filtering)</li>
+    <li><strong>Scalable:</strong> HTTP POST is stateless and easier to load balance</li>
+    <li><strong>No persistent connections:</strong> No need to maintain long-lived SSH connections for event delivery</li>
+    <li><strong>Cloud-friendly:</strong> Works well with reverse proxies, load balancers, and cloud environments</li>
+</ul>
+
+<p><strong>Considerations:</strong></p>
+<ul>
+    <li>Requires webhook configuration on the Gerrit server side</li>
+    <li>Still needs SSH connection for sending build results (bidirectional communication not possible over webhooks)</li>
+    <li>Should enable webhook authentication to prevent unauthorized requests</li>
+    <li>May have slightly higher latency than SSH streaming (depends on Gerrit webhook delivery)</li>
+</ul>
+
+<p><strong>Security Configuration:</strong></p>
+<p>When webhook authentication is enabled, you can configure:</p>
+<ul>
+    <li><strong>Secret Token:</strong> Shared token validated from HTTP headers or query parameters</li>
+    <li><strong>HMAC Signature:</strong> Cryptographic validation of payload integrity using HMAC-SHA256</li>
+    <li><strong>IP Whitelisting:</strong> Restrict access to specific Gerrit server IP addresses</li>
+</ul>

--- a/src/main/webapp/help-WebhookAllowedIps.html
+++ b/src/main/webapp/help-WebhookAllowedIps.html
@@ -1,0 +1,27 @@
+<p>A comma-separated list of IP addresses that are allowed to send webhook requests to Jenkins.</p>
+
+<p><strong>Format:</strong> Enter IP addresses separated by commas, for example:</p>
+<code>192.168.1.10, 10.0.0.5, 172.16.0.100</code>
+
+<p><strong>Behavior:</strong></p>
+<ul>
+    <li>If this list is <strong>empty</strong>, webhook requests from any IP address will be accepted (no IP filtering)</li>
+    <li>If this list contains IP addresses, only requests from those IPs will be accepted</li>
+    <li>Requests from other IP addresses will be rejected with HTTP 401 Unauthorized</li>
+</ul>
+
+<p><strong>Proxy Considerations:</strong> The plugin automatically checks the following headers to determine the real client IP:</p>
+<ul>
+    <li><code>X-Forwarded-For</code> (takes the first IP if multiple are present)</li>
+    <li><code>X-Real-IP</code></li>
+    <li>Remote address (if no proxy headers are present)</li>
+</ul>
+
+<p><strong>Security Note:</strong> IP whitelisting provides network-level security but should be combined with token or HMAC authentication for defense-in-depth.</p>
+
+<p><strong>Example use cases:</strong></p>
+<ul>
+    <li>Restrict to your Gerrit server IP(s): <code>192.168.1.50</code></li>
+    <li>Allow multiple Gerrit servers: <code>192.168.1.50, 192.168.1.51</code></li>
+    <li>Allow all IPs (not recommended): Leave empty</li>
+</ul>

--- a/src/main/webapp/help-WebhookConfig.html
+++ b/src/main/webapp/help-WebhookConfig.html
@@ -1,0 +1,12 @@
+<p>Enable authentication and security features for the webhook endpoint.</p>
+
+<p>When enabled, you can configure multiple authentication methods to secure your webhook endpoint:</p>
+<ul>
+    <li><strong>Secret Token:</strong> A shared secret token that must be provided in webhook requests</li>
+    <li><strong>HMAC Signature:</strong> Validates request payload integrity using HMAC-SHA256 signatures</li>
+    <li><strong>IP Whitelisting:</strong> Restricts webhook access to specific IP addresses</li>
+</ul>
+
+<p><strong>Security Note:</strong> It is highly recommended to enable at least one authentication method for production environments to prevent unauthorized webhook requests.</p>
+
+<p>If disabled, the webhook endpoint will accept requests from any source without authentication (not recommended for production).</p>

--- a/src/main/webapp/help-WebhookHmacSecret.html
+++ b/src/main/webapp/help-WebhookHmacSecret.html
@@ -1,0 +1,15 @@
+<p>A shared secret key used to validate the integrity of webhook payloads using HMAC-SHA256 signatures.</p>
+
+<p>When configured, Gerrit will compute an HMAC signature of the webhook payload using this secret and include it in the <code>X-Gerrit-Signature</code> HTTP header as: <code>sha256=&lt;signature&gt;</code></p>
+
+<p>Jenkins will verify the signature to ensure:</p>
+<ul>
+    <li>The payload was sent by an authorized source (has the secret)</li>
+    <li>The payload was not tampered with during transmission</li>
+</ul>
+
+<p><strong>Configuration in Gerrit:</strong> Configure the same HMAC secret in your Gerrit server's webhook settings to enable signature validation.</p>
+
+<p><strong>Note:</strong> HMAC signature validation provides stronger security than simple token authentication as it validates payload integrity.</p>
+
+<p><strong>Security:</strong> The secret is stored encrypted in Jenkins. Use a strong, random value (at least 32 characters recommended).</p>

--- a/src/main/webapp/help-WebhookRequireHmac.html
+++ b/src/main/webapp/help-WebhookRequireHmac.html
@@ -1,0 +1,16 @@
+<p>When enabled, webhook requests <strong>must</strong> include a valid HMAC-SHA256 signature to be accepted.</p>
+
+<p>The signature must be provided in the <code>X-Gerrit-Signature</code> HTTP header in the format: <code>sha256=&lt;hex-signature&gt;</code></p>
+
+<p>If this option is disabled (unchecked), the HMAC secret configuration is ignored and requests are accepted without signature validation.</p>
+
+<p><strong>Recommended:</strong> Enable this option if you have configured an HMAC secret to ensure payload integrity and authenticity.</p>
+
+<p><strong>Security Benefit:</strong> HMAC signature validation is more secure than simple token authentication because it:</p>
+<ul>
+    <li>Validates the entire payload content (detects tampering)</li>
+    <li>Prevents replay attacks when combined with timestamps</li>
+    <li>Provides cryptographic proof of authenticity</li>
+</ul>
+
+<p><strong>Use case for disabling:</strong> You may want to disable this if you're using only token-based authentication or IP whitelisting, without HMAC signature validation.</p>

--- a/src/main/webapp/help-WebhookRequireSecret.html
+++ b/src/main/webapp/help-WebhookRequireSecret.html
@@ -1,0 +1,7 @@
+<p>When enabled, webhook requests <strong>must</strong> include a valid secret token to be accepted.</p>
+
+<p>If this option is disabled (unchecked), the secret token configuration is ignored and requests are accepted without token validation.</p>
+
+<p><strong>Recommended:</strong> Enable this option if you have configured a webhook secret token to ensure requests are authenticated.</p>
+
+<p><strong>Use case for disabling:</strong> You may want to disable this if you're using only HMAC signature validation or IP whitelisting for authentication, without token-based authentication.</p>

--- a/src/main/webapp/help-WebhookSecret.html
+++ b/src/main/webapp/help-WebhookSecret.html
@@ -1,0 +1,12 @@
+<p>A shared secret token used to authenticate webhook requests from Gerrit.</p>
+
+<p>The token must be provided by Gerrit in one of the following ways:</p>
+<ul>
+    <li>In the <code>X-Gerrit-Token</code> HTTP header</li>
+    <li>In the <code>Authorization: Bearer &lt;token&gt;</code> HTTP header</li>
+    <li>As a query parameter: <code>?token=&lt;token&gt;</code></li>
+</ul>
+
+<p><strong>Configuration in Gerrit:</strong> You need to configure this same token in your Gerrit server's webhook configuration for the webhook to be accepted.</p>
+
+<p><strong>Note:</strong> The token is stored encrypted in Jenkins. Choose a strong, random value for production use.</p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerWebhookConfigTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerWebhookConfigTest.java
@@ -60,7 +60,6 @@ public class GerritServerWebhookConfigTest {
         // Create connectionType object with nested fields (radioBlock structure)
         JSONObject connectionTypeData = new JSONObject();
         connectionTypeData.put("value", "WEBHOOK");
-        connectionTypeData.put("logWebhookRequests", false);
 
         // Create webhook authentication config (nested inside connectionType)
         JSONObject webhookData = new JSONObject();
@@ -186,7 +185,6 @@ public class GerritServerWebhookConfigTest {
         // Create connectionType object with nested fields (radioBlock structure)
         JSONObject connectionTypeData = new JSONObject();
         connectionTypeData.put("value", "WEBHOOK");
-        connectionTypeData.put("logWebhookRequests", true);
 
         // Create webhook authentication config (nested inside connectionType)
         JSONObject webhookData = new JSONObject();
@@ -216,7 +214,6 @@ public class GerritServerWebhookConfigTest {
         assertEquals("Require secret token should be copied", true, copiedWebhookConfig.isRequireSecretToken());
         assertEquals("Require HMAC signature should be copied", true,
                     copiedWebhookConfig.isRequireHmacSignature());
-        assertEquals("Log requests should be copied", true, copiedConfig.isLogWebhookRequests());
 
         // Verify it's a deep copy (not the same object)
         assertNotNull("Original webhook config should exist", originalConfig.getWebhookConfig());

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticatorTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticatorTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Your Name &lt;your.email@domain.com&gt;
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class WebhookAuthenticatorTest {
 
     private static final int TEST_ITERATIONS = 1000;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticatorTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/webhook/WebhookAuthenticatorTest.java
@@ -63,13 +63,13 @@ public class WebhookAuthenticatorTest {
 
     @Test
     public void testAuthenticateWithNullRequest() {
-        boolean result = authenticator.authenticate(null, mockServer);
+        boolean result = authenticator.authenticate(null, mockServer, null);
         assertFalse("Should fail authentication with null request", result);
     }
 
     @Test
     public void testAuthenticateWithNullServer() {
-        boolean result = authenticator.authenticate(mockRequest, null);
+        boolean result = authenticator.authenticate(mockRequest, null, null);
         assertFalse("Should fail authentication with null server", result);
     }
 
@@ -84,7 +84,7 @@ public class WebhookAuthenticatorTest {
 
         // Since no webhook configuration is available (returns null),
         // authentication should pass by default
-        boolean result = authenticator.authenticate(mockRequest, mockServer);
+        boolean result = authenticator.authenticate(mockRequest, mockServer, null);
         assertTrue("Should pass authentication when no configuration is available", result);
     }
 
@@ -97,7 +97,7 @@ public class WebhookAuthenticatorTest {
         // Use reflection to access private method for testing
         // This would need to be refactored or made package-private for proper testing
         assertTrue("Should pass basic authentication",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, null));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class WebhookAuthenticatorTest {
 
         // Should still pass authentication (no IP restrictions configured)
         assertTrue("Should pass authentication with X-Forwarded-For header",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, null));
     }
 
     @Test
@@ -117,7 +117,7 @@ public class WebhookAuthenticatorTest {
 
         // Should still pass authentication (no IP restrictions configured)
         assertTrue("Should pass authentication with multiple forwarded IPs",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, null));
     }
 
     @Test
@@ -128,7 +128,7 @@ public class WebhookAuthenticatorTest {
 
         // Should pass since no token validation is configured
         assertTrue("Should pass authentication with token header",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, null));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class WebhookAuthenticatorTest {
 
         // Should pass since no token validation is configured
         assertTrue("Should pass authentication with Authorization Bearer token",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, null));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class WebhookAuthenticatorTest {
 
         // Should pass since no token validation is configured
         assertTrue("Should pass authentication with query parameter token",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, null));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class WebhookAuthenticatorTest {
 
         // Should pass since no HMAC validation is configured
         assertTrue("Should pass authentication with HMAC signature",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, "{\"type\":\"patchset-created\"}"));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class WebhookAuthenticatorTest {
 
         // For now, we can only test through the public authenticate method
         assertTrue("Authentication should handle null values gracefully",
-                  authenticator.authenticate(mockRequest, mockServer));
+                  authenticator.authenticate(mockRequest, mockServer, ""));
     }
 
     @Test
@@ -187,7 +187,7 @@ public class WebhookAuthenticatorTest {
         long startTime = System.currentTimeMillis();
 
         for (int i = 0; i < TEST_ITERATIONS; i++) {
-            authenticator.authenticate(mockRequest, mockServer);
+            authenticator.authenticate(mockRequest, mockServer, null);
         }
 
         long endTime = System.currentTimeMillis();


### PR DESCRIPTION
Fix https://github.com/sboardwell/gerrit-trigger-plugin/issues/4

- The level for the authentication errors moved to FINE to avoid DoS
- isLoggable is necessary in some locations (like `AuthenticationCrumb`) for performance reasons (to avoid creating an array for any request, for example).
- Added the code to accomplish the HMAC authentication feature. Since we already have the payload in the Receiver, we got it from there.

Any questions or doubts, just ping me.